### PR TITLE
Fix doClean() of sfValidatorBoolean

### DIFF
--- a/lib/validator/sfValidatorBoolean.class.php
+++ b/lib/validator/sfValidatorBoolean.class.php
@@ -33,8 +33,8 @@ class sfValidatorBoolean extends sfValidatorBase
    */
   protected function configure($options = array(), $messages = array())
   {
-    $this->addOption('true_values', array('true', 't', 'yes', 'y', 'on', '1'));
-    $this->addOption('false_values', array('false', 'f', 'no', 'n', 'off', '0'));
+    $this->addOption('true_values', array('true', 't', 'yes', 'y', 'on', '1', true, 1));
+    $this->addOption('false_values', array('false', 'f', 'no', 'n', 'off', '0', false, 0));
 
     $this->setOption('required', false);
     $this->setOption('empty_value', false);
@@ -45,12 +45,12 @@ class sfValidatorBoolean extends sfValidatorBase
    */
   protected function doClean($value)
   {
-    if (in_array($value, $this->getOption('true_values')))
+    if (in_array($value, $this->getOption('true_values'), true))
     {
       return true;
     }
 
-    if (in_array($value, $this->getOption('false_values')))
+    if (in_array($value, $this->getOption('false_values'), true))
     {
       return false;
     }


### PR DESCRIPTION
Due to loose comparision in `in_array()` unexpected results occure, i.e.:
`$value = 0` results in cleaning the value to `true` instead of `false`
because `in_array(0, ['true', 't', 'yes', 'y', 'on', '1']) = true` since
`0 == 'true'` => `0 === (int)'true'` => `0 === 0` 

To fix that enable type strict comparison in `in_array()` and add boolean values as well as usual integer values to 'true_values' and 'false_values' options